### PR TITLE
#4 extension.js: Added 'file://' to picture-uri

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -85,7 +85,7 @@ function notifyError(msg) {
 
 function doSetBackground(uri, schema, setDrawBackground) {
     let gsettings = new Gio.Settings({schema: schema});
-    gsettings.set_string('picture-uri', uri);
+    gsettings.set_string('picture-uri', 'file://' + uri);
     gsettings.set_string('picture-options', 'zoom');
     if (setDrawBackground)
         gsettings.set_boolean('draw-background', true);


### PR DESCRIPTION
The goal is to let Nautilus desktop recognize it as a valid uri so it is displayed as the desktop background.

**Note:**
I am currently using *gdm*. I don't know how it works with *lightdm*. This may be missing something, as there is a specific function for it on the code `doSetBackgroundLightDM()` which I didn't touch. Should 'file://' be added to that uri as well??