### PR TITLE
Fix to work using urlbase

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -303,7 +303,7 @@ const BingWallpaperIndicator = new Lang.Class({
                 resolution = "1920x1080";
             }
 
-            this.imageURL = BingURL+imagejson['url'].replace('1920x1080',resolution); // mangle url to user's resolution
+            this.imageURL = BingURL+imagejson['urlbase']+"_"+resolution+".jpg"; // mangle url to user's resolution
 
             let BingWallpaperDir = this._settings.get_string('download-folder');
             let userPicturesDir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_PICTURES);


### PR DESCRIPTION
Replace 1920x1080 to custom resolution not work in brazilian portuguese. [Bing set 1366x768 screen resolution for brazilian](https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1&mbl=1&mkt=pt-BR). So resolution customization was never being applied, this commit solve this.