### PR TITLE
Properly extract file names from the query string

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -331,7 +331,7 @@ const BingWallpaperIndicator = new Lang.Class({
             }
 
             log("XDG pictures directory detected as "+userPicturesDir+" saving pictures to "+BingWallpaperDir);
-            this.filename = BingWallpaperDir+imagejson['startdate']+'-'+this.imageURL.replace(/^.*[\\\/]/, '');
+            this.filename = BingWallpaperDir+imagejson['startdate']+'-'+this.imageURL.replace(/^.*[\\\/]/, '').replace('th?id=OHR.', '');
             let file = Gio.file_new_for_path(this.filename);
             let file_exists = file.query_exists(null);
             let file_info = file_exists ? file.query_info ('*',Gio.FileQueryInfoFlags.NONE,null): 0;


### PR DESCRIPTION
Bing changes its URL format for homepage images to be `/th?id=OHR.[filename].jpg` (https://www.bing.com/HPImageArchive.aspx?format=js&n=1). This pull request updates the code that extract file names from the image URL accordingly.

Closes #45 