### PR TITLE
add support for UHD

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -32,8 +32,8 @@ const TIMEOUT_SECONDS_ON_HTTP_ERROR = 1 * 3600; // retry in one hour if there is
 const ICON_DEFAULT = "simple-frame";
 
 let monitors;
-let validresolutions = [ '800x600' , '1024x768', '1280x720', '1280x768', '1366x768', '1920x1080', '1920x1200'];
-let aspectratios = [ -1, 1.33, -1, 1.67, 1.78, 1.78, 1.6]; // width / height (ignore the lower res equivalents)
+let validresolutions = [ '800x600' , '1024x768', '1280x720', '1280x768', '1366x768', '1920x1080', '1920x1200', 'UHD'];
+let aspectratios = [ -1, 1.33, -1, 1.67, 1.78, 1.78, 1.6, -1]; // width / height (ignore the lower res equivalents)
 
 let monitorW; // largest (in pixels) monitor width
 let monitorH; // largest (in pixels) monitor height
@@ -568,7 +568,8 @@ function enable() {
     autores = monitorW+"x"+monitorH;
 
     if (validresolutions.indexOf(autores) == -1) {
-        autores = "1920x1080"; // default to this, as people don't like the Bing logo
+        // default to 1080, as people don't like the Bing logo
+        autores = monitorW > 1920 ? "UHD" : "1920x1080";
         log("unknown resolution, defaulted to "+autores);
     }
     else {

--- a/prefs.js
+++ b/prefs.js
@@ -37,7 +37,7 @@ let marketName = [
   "українська (Україна)", "中文（中国）", "中文（中國香港特別行政區）", "中文（台灣）"
 ];
 
-let resolutions = [ 'auto', '1920x1200', '1920x1080', '1366x768', '1280x720', '1024x768', '800x600'];
+let resolutions = ['auto', 'UHD', '1920x1200', '1920x1080', '1366x768', '1280x720', '1024x768', '800x600'];
 let marketDescription = null;
 let icon_image = null;
 

--- a/schemas/org.gnome.shell.extensions.bingwallpaper.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.bingwallpaper.gschema.xml
@@ -48,7 +48,7 @@
     <key name="resolution" type="s">
       <default>"auto"</default>
       <summary>Screen Size</summary>
-      <description>Valid sizes are '800x600' , '1024x768', '1280x720', '1280x768', '1366x768', '1920x1080', and '1920x1200' </description>
+      <description>Valid sizes are '800x600', '1024x768', '1280x720', '1280x768', '1366x768', '1920x1080', '1920x1200' and 'UHD'</description>
     </key>
 
     <key name="debug-logging" type="b">


### PR DESCRIPTION
If the monitor is wider than 1920, choose the UHD image.

Work well for me on 4K displays.