### PR TITLE
GTK4 margin name property changes

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -50,8 +50,8 @@ Bing Wallpaper GNOME extension by: Michael Carroll
       <object class="GtkBox" id="settings_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">12</property>
-        <property name="margin_right">12</property>
+        <property name="margin-start">12</property>
+        <property name="margin-end">12</property>
         <property name="margin_top">12</property>
         <property name="margin_bottom">12</property>
         <property name="orientation">vertical</property>


### PR DESCRIPTION
GTK4 now has margin-start and margin-end instead of margin-right and margin-left

https://gjs.guide/extensions/upgrading/gnome-shell-40.html#no-margin-left-and-margin-right-property

Fixes #98 