### PR TITLE
Support blurring lock screen in Gnome 4x > 40

### DIFF
--- a/blur.js
+++ b/blur.js
@@ -137,7 +137,7 @@ var Blur = class Blur {
 };
 
 function whichVersion() {
-    if ((shellVersionMajor == 3 && shellVersionMinor >= 36) || shellVersionMajor == 40) {
+    if ((shellVersionMajor == 3 && shellVersionMinor >= 36) || shellVersionMajor >= 40) {
         if (shellVersionMajor == 3 && shellVersionMinor == 36 && shellVersionPoint <= 3) {
             return 1;
         }


### PR DESCRIPTION
v39 of the extension drops Gnome 42 through to the "unsupported version" logic.

Checking that we're v40 or greater supports future Gnome versions.