### PR TITLE
typo: Gnome -> GNOME

### DIFF
--- a/ui/Settings.ui
+++ b/ui/Settings.ui
@@ -1591,7 +1591,7 @@ Bing Wallpaper GNOME extension by: Michael Carroll
               <object class="GtkLabel" id="extension_version_label">
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Gnome shell extension version </property>
+                <property name="label" translatable="yes">GNOME shell extension version </property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1712,7 +1712,7 @@ Bing Wallpaper GNOME extension by: Michael Carroll
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Based on NASA APOD Gnome shell extension by Elia Argentieri</property>
+                <property name="label" translatable="yes">Based on NASA APOD GNOME shell extension by Elia Argentieri</property>
                 <property name="justify">center</property>
                 <property name="wrap">True</property>
                 <attributes>

--- a/ui/Settings4.ui
+++ b/ui/Settings4.ui
@@ -1451,7 +1451,7 @@ Bing Wallpaper GNOME extension by: Michael Carroll
                   <object class="GtkLabel">
                     <property name="can_focus">0</property>
                     <property name="margin-start">36</property>
-                    <property name="label" translatable="yes">Based on NASA APOD Gnome shell extension by Elia Argentieri</property>
+                    <property name="label" translatable="yes">Based on NASA APOD GNOME shell extension by Elia Argentieri</property>
                     <property name="justify">center</property>
                     <property name="wrap">1</property>
                     <attributes>

--- a/utils.js
+++ b/utils.js
@@ -647,7 +647,7 @@ function toFilename(wallpaperDir, startdate, imageURL, resolution) {
 function initSoup() {
     try {
         let httpSession = new Soup.Session();
-        httpSession.user_agent = 'User-Agent: Mozilla/5.0 (X11; GNOME Shell/' + imports.misc.config.PACKAGE_VERSION + '; Linux x86_64; +https://github.com/neffo/bing-wallpaper-gnome-extension ) BingWallpaper Gnome Extension/' + Me.metadata.version;
+        httpSession.user_agent = 'User-Agent: Mozilla/5.0 (X11; GNOME Shell/' + imports.misc.config.PACKAGE_VERSION + '; Linux x86_64; +https://github.com/neffo/bing-wallpaper-gnome-extension ) BingWallpaper GNOME Extension/' + Me.metadata.version;
         return httpSession;
     }
     catch (e) {


### PR DESCRIPTION
We should follow the brand naming of GNOME.