### PR TITLE
Bug #239: fix lockscreen dimming

### DIFF
--- a/blur.js
+++ b/blur.js
@@ -20,6 +20,7 @@ var shellVersionMajor = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 var shellVersionMinor = parseInt(Config.PACKAGE_VERSION.split('.')[1]);
 var shellVersionPoint = parseInt(Config.PACKAGE_VERSION.split('.')[2]);
 
+var blurField = shellVersionMajor >= 46 ? "radius" : "sigma";
 // default BWP mild blur
 var BWP_BLUR_SIGMA = 2;
 var BWP_BLUR_BRIGHTNESS = 55;
@@ -50,7 +51,7 @@ export function _updateBackgroundEffects_BWP(monitorIndex) {
             if (effect) {
                 effect.set({ // GNOME defaults when login prompt is visible
                     brightness: BLUR_BRIGHTNESS,
-                    sigma: BLUR_SIGMA * themeContext.scale_factor,
+                    [blurField]: BLUR_SIGMA * themeContext.scale_factor,
                 });
             }
         }
@@ -59,7 +60,7 @@ export function _updateBackgroundEffects_BWP(monitorIndex) {
             if (effect) {
                 effect.set({ // adjustable blur when clock is visible
                     brightness: BWP_BLUR_BRIGHTNESS * 0.01, // we use 0-100 rather than 0-1, so divide by 100
-                    sigma: BWP_BLUR_SIGMA * themeContext.scale_factor,
+                    [blurField]: BWP_BLUR_SIGMA * themeContext.scale_factor,
                 });
             }
         }

--- a/blur.js
+++ b/blur.js
@@ -92,7 +92,7 @@ export function _clampValue(value) {
 export default class Blur {
     constructor() {
         this.enabled = false;
-        log('Bing Wallpaper adjustable blur is '+supportedVersion()?'available':'not available');
+        log('Bing Wallpaper adjustable blur is '+(supportedVersion()?'available':'not available'));
     }
 
     set_blur_strength(value) {

--- a/extension.js
+++ b/extension.js
@@ -229,6 +229,8 @@ class BingWallpaperIndicator extends Button {
             {signal: 'changed::market', call: this._refresh},
             {signal: 'changed::set-background', call: this._setBackground},
             {signal: 'changed::override-lockscreen-blur', call: this._setBlur},
+            {signal: 'changed::lockscreen-blur-strength', call: this._setBlur},
+            {signal: 'changed::lockscreen-blur-brightness', call: this._setBlur},
             {signal: 'changed::selected-image', call: this._setImage},
             {signal: 'changed::delete-previous', call: this._cleanUpImages},
             {signal: 'changed::notify', call: this._notifyCurrentImage},
@@ -246,9 +248,6 @@ class BingWallpaperIndicator extends Button {
         settingConnections.forEach((e) => {
             this._settings.connect(e.signal, e.call.bind(this));
         });
-
-        this._settings.connect('changed::lockscreen-blur-strength', blur.set_blur_strength.bind(this, this._settings.get_int('lockscreen-blur-strength')));
-        this._settings.connect('changed::lockscreen-blur-brightness', blur.set_blur_brightness.bind(this, this._settings.get_int('lockscreen-blur-brightness')));        
         
         // ensure we're in a sensible initial state
         this._setIcon();

--- a/extension.js
+++ b/extension.js
@@ -220,9 +220,13 @@ class BingWallpaperIndicator extends Button {
 
     // listen for configuration changes
     _setConnections() {
-        this._settings.connect('changed::hide', () => {
-            this.visible = !this._settings.get_boolean('hide');
-        });
+        this.settings_connections = [];
+
+        this.settings_connections.push(
+            this._settings.connect('changed::hide', () => {
+                this.visible = !this._settings.get_boolean('hide');
+            })
+        );
         
         let settingConnections = [
             {signal: 'changed::icon-name', call: this._setIcon},
@@ -246,7 +250,9 @@ class BingWallpaperIndicator extends Button {
 
         // _setShuffleToggleState
         settingConnections.forEach((e) => {
-            this._settings.connect(e.signal, e.call.bind(this));
+            this.settings_connections.push(
+                this._settings.connect(e.signal, e.call.bind(this))
+            );
         });
         
         // ensure we're in a sensible initial state
@@ -281,10 +287,12 @@ class BingWallpaperIndicator extends Button {
                         /*{key: 'random-mode-include-only-unhidden', toggle: this.toggleShuffleOnlyUnhidden},*/
                         {key: 'random-mode-include-only-uhd', toggle: this.toggleShuffleOnlyUHD}];
         
-        toggles.forEach( (e) => { 
-            this._settings.connect('changed::'+e.key, () => { 
-                e.toggle.setToggleState(this._settings.get_boolean(e.key));
-            });
+        toggles.forEach( (e) => {
+            this.settings_connections.push(
+                this._settings.connect('changed::'+e.key, () => {
+                    e.toggle.setToggleState(this._settings.get_boolean(e.key));
+                })
+            );
             e.toggle.connect('toggled', (item, state) => {
                 this._settings.set_boolean(e.key, state);
             });
@@ -300,6 +308,16 @@ class BingWallpaperIndicator extends Button {
                 forEach(e => e.setSensitive(false));
         }
     }  
+
+    _onDestroy() {
+        this._unsetConnections();
+    }
+
+    _unsetConnections() {
+        this.settings_connections.forEach((e) => {
+            this._settings.disconnect(e);
+        });
+    }
 
     _openPrefs() {
         this._extension.openPreferences();


### PR DESCRIPTION
I think I've managed to fix the lockscreen dimming (#239) and some related issues.

The commit messages have more detail, but basically:
* Gnome 46 seems to have changed one of the blur parameters
* The events were hooked up a little strangely and weren't applying consistently (or were applying repeatedly!) until I adjusted the setting change handling

I'm running this locally and I haven't seen any issues yet.