### PR TITLE
Replaced Clutter.Image with St.ImageContent (fixes GNOME 48)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -565,6 +565,7 @@ class BingWallpaperIndicator extends Button {
 
         const image = new St.ImageContent();
         const success = image.set_data(
+            Clutter.get_default_backend().get_cogl_context(),
             pixbuf.get_pixels(),
             pixbuf.get_has_alpha() ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888,
             width,

--- a/extension.js
+++ b/extension.js
@@ -574,7 +574,7 @@ class BingWallpaperIndicator extends Button {
         );
 
         if (!success) {
-            throw Error("error creating Clutter.Image()");
+            throw Error("error creating St.ImageContent()");
         }
 
         this.thumbnailItem.hexpand = false;

--- a/extension.js
+++ b/extension.js
@@ -563,15 +563,16 @@ class BingWallpaperIndicator extends Button {
             return;
         }
 
+        const [version] = Config.PACKAGE_VERSION.split('.').map(s => Number(s));
         const image = new St.ImageContent();
-        const success = image.set_data(
-            Clutter.get_default_backend().get_cogl_context(),
+        const success = image.set_data.apply(image, [
+            ...version >= 48 ? [Clutter.get_default_backend().get_cogl_context()] : [],
             pixbuf.get_pixels(),
             pixbuf.get_has_alpha() ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888,
             width,
             height,
-            pixbuf.get_rowstride()
-        );
+            pixbuf.get_rowstride(),
+        ]);
 
         if (!success) {
             throw Error("error creating St.ImageContent()");

--- a/extension.js
+++ b/extension.js
@@ -563,7 +563,7 @@ class BingWallpaperIndicator extends Button {
             return;
         }
 
-        const image = new Clutter.Image();
+        const image = new St.ImageContent();
         const success = image.set_data(
             pixbuf.get_pixels(),
             pixbuf.get_has_alpha() ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888,


### PR DESCRIPTION
According to https://gitlab.gnome.org/jrahmatzadeh/gjs-guide/-/commit/b150648e7ad460a9cff3afeecdbdb6b8d17550ab, Clutter.Image will not work in GNOME 48 - replaced it with St.ImageContent, recommended by the porting guide. This is backwards compatible with GNOME Shell 45 and higher.

> ## GJS
> 
> ## `Clutter.Image`
> 
> `Clutter.Image` has been removed and you can use [`St.ImageContent`] instead.
> There is no need to version check for `St.ImageContent`
> as it's already available in GNOME Shell 45 and higher.
> 
> [`St.ImageContent`]: https://gjs-docs.gnome.org/st15~15/st.imagecontent
