### PR TITLE
Fix gallery button absency

### DIFF
--- a/locale/BingWallpaper.pot
+++ b/locale/BingWallpaper.pot
@@ -1,4 +1,4 @@
-#: ui/prefsadw.ui.h:1 extension.js:146
+#: ui/prefsadw.ui.h:1 extension.js:145
 msgid "Settings"
 msgstr ""
 
@@ -130,7 +130,7 @@ msgstr ""
 msgid "Advanced options"
 msgstr ""
 
-#: ui/prefsadw.ui.h:34 extension.js:160
+#: ui/prefsadw.ui.h:34 extension.js:159
 msgid "Always show new images"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgstr ""
 msgid "<image name here>"
 msgstr ""
 
-#: ui/carousel4.ui.h:7 extension.js:161
+#: ui/carousel4.ui.h:7 extension.js:160
 msgid "Image shuffle mode"
 msgstr ""
 
@@ -290,83 +290,83 @@ msgstr ""
 msgid "User defined interval"
 msgstr ""
 
-#: extension.js:137
+#: extension.js:136
 msgid "<No refresh scheduled>"
 msgstr ""
 
-#: extension.js:138 extension.js:139 extension.js:149 extension.js:151
+#: extension.js:137 extension.js:138 extension.js:148 extension.js:150
 msgid "Awaiting refresh..."
 msgstr ""
 
-#: extension.js:140
+#: extension.js:139
 msgid "Copy image to clipboard"
 msgstr ""
 
-#: extension.js:141
+#: extension.js:140
 msgid "Copy image URL to clipboard"
 msgstr ""
 
-#: extension.js:142
+#: extension.js:141
 msgid "Open image folder"
 msgstr ""
 
-#: extension.js:143 extension.js:159
+#: extension.js:142 extension.js:158
 msgid "Set background image"
 msgstr ""
 
-#: extension.js:144
+#: extension.js:143
 msgid "Set lock screen image"
 msgstr ""
 
-#: extension.js:145
+#: extension.js:144
 msgid "Refresh Now"
 msgstr ""
 
-#: extension.js:147
+#: extension.js:146
 msgid "Open in image viewer"
 msgstr ""
 
-#: extension.js:148
+#: extension.js:147
 msgid "Open Bing image information page"
 msgstr ""
 
-#: extension.js:157
+#: extension.js:156
 msgid "Quick settings"
 msgstr ""
 
-#: extension.js:162
+#: extension.js:161
 msgid "Image shuffle only favorites"
 msgstr ""
 
-#: extension.js:164
+#: extension.js:163
 msgid "Show image count"
 msgstr ""
 
-#: extension.js:165
+#: extension.js:164
 msgid "Image shuffle only UHD resolutions"
 msgstr ""
 
-#: extension.js:361
+#: extension.js:360
 msgid "Next refresh"
 msgstr ""
 
-#: extension.js:363
+#: extension.js:362
 msgid "Last refresh"
 msgstr ""
 
-#: extension.js:366
+#: extension.js:365
 msgid "Next shuffle"
 msgstr ""
 
-#: extension.js:859 extension.js:947
+#: extension.js:858 extension.js:946
 msgid "Bing Wallpaper of the Day for"
 msgstr ""
 
-#: extension.js:985
+#: extension.js:984
 msgid "No wallpaper available"
 msgstr ""
 
-#: extension.js:986
+#: extension.js:985
 msgid "No picture for today."
 msgstr ""
 

--- a/ui/carousel4.ui
+++ b/ui/carousel4.ui
@@ -52,7 +52,7 @@ Author: Michael Carroll
         <property name="can-focus">0</property>
         <property name="homogeneous">0</property>
         <property name="spacing">5</property>
-        <!-- <property name="orientation">vertical</property> -->
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkPicture" id="galleryImage">
             <property name="width-request">320</property>
@@ -65,8 +65,9 @@ Author: Michael Carroll
         <child>
           <object class="GtkBox" id="buttonBar">
             <property name="can-focus">0</property>
-            <property name="orientation">vertical</property>
-            <property name="vexpand">1</property>
+            <property name="orientation">horizontal</property>
+            <property name="vexpand">0</property>
+            <property name="halign">center</property>
             <property name="valign">center</property>
             <style>
                 <class name="linked"/>
@@ -200,6 +201,7 @@ Author: Michael Carroll
           <object class="GtkButton" id="loadButton">
             <property name="label" translatable="yes">Load image gallery</property>
             <property name="receives-default">1</property>
+            <property name="halign">center</property>
             <layout>
               <property name="column">0</property>
               <property name="row">1</property>

--- a/ui/prefsadw.ui
+++ b/ui/prefsadw.ui
@@ -166,26 +166,30 @@ Bing Wallpaper GNOME extension by: Michael Carroll
         <property name="icon-name">emblem-photos-symbolic</property>
         <property name="title" translatable="yes">Gallery</property>
         <child>
-            <object class="GtkScrolledWindow" id="carouselViewPort">
-            <property name="can-focus">0</property>
-            <property name="height_request">500</property>
-            <property name="hexpand">0</property>
-            <property name="vexpand">0</property>
-            <property name="child">
-              <object class="GtkBox">
+            <object class="AdwPreferencesGroup" id="gallery_group">
                 <child>
-                    <object class="GtkFlowBox" id="carouselFlowBox">
+                    <object class="GtkScrolledWindow" id="carouselViewPort">
                         <property name="can-focus">0</property>
-                        <property name="halign">center</property>
-                        <property name="homogeneous">1</property>
-                        <property name="max-children-per-line">2</property>
-                        <property name="min-children-per-line">2</property>
-                        <property name="row-spacing">2</property>
-                        <property name="column-spacing">2</property>
+                        <property name="height_request">500</property>
+                        <property name="hexpand">1</property>
+                        <property name="vexpand">1</property>
+                        <property name="child">
+                            <object class="GtkBox">
+                                <child>
+                                    <object class="GtkFlowBox" id="carouselFlowBox">
+                                        <property name="can-focus">0</property>
+                                        <property name="halign">center</property>
+                                        <property name="homogeneous">1</property>
+                                        <property name="max-children-per-line">2</property>
+                                        <property name="min-children-per-line">2</property>
+                                        <property name="row-spacing">2</property>
+                                        <property name="column-spacing">2</property>
+                                    </object>
+                                </child>
+                            </object>
+                        </property>
                     </object>
                 </child>
-              </object>
-            </property>
             </object>
         </child>
     </object>


### PR DESCRIPTION
So I've encountered the same issue as described in [this one](https://github.com/neffo/bing-wallpaper-gnome-extension/issues/276).

I didn't have much time, so I've just vibecoded the solution and also changed the placement of buttons in gallery so that they always fit (I know it's dumb to put it in the same commit, but whatever)

So yeah, it looks weird, but it work, bruh
<img width="745" height="751" alt="image" src="https://github.com/user-attachments/assets/3aa7c13c-4e2d-443e-8ec8-220dc6c86969" />
