### PR TITLE
Pin in-flight Soup.Message wrappers to silence libsoup runtime check

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -213,6 +213,11 @@ class BingWallpaperIndicator extends Button {
     _initSoup() {
         this.httpSession = new Soup.Session();
         this.httpSession.user_agent = 'User-Agent: Mozilla/5.0 (X11; GNOME Shell/' + Config.PACKAGE_VERSION + '; Linux x86_64; +https://github.com/neffo/bing-wallpaper-gnome-extension ) BingWallpaper Gnome Extension/' + this._extension.metadata.version;
+        // Pin in-flight Soup.Message wrappers so libsoup can finish
+        // tearing down the queue item before GC reaps the JS wrapper —
+        // otherwise we trip
+        // `soup_message_queue_item_destroy: ... item->msg) == NULL`.
+        this._pendingMessages = new Set();
     }
 
     // listen for configuration changes
@@ -664,13 +669,21 @@ class BingWallpaperIndicator extends Button {
 
             let request = Soup.Message.new_from_encoded_form('GET', url, Soup.form_encode_hash(params));
             request.request_headers.append('Accept', 'application/json');
+            this._pendingMessages?.add(request);
 
             try {
-                await this.httpSession.send_and_read_async(request, GLib.PRIORITY_DEFAULT, null, (httpSession, message) => {
-                    this._processMessageRefresh(message);
+                // Soup 3 callback is (session, asyncResult); the message we
+                // pinned lives in the closure as `request`.
+                await this.httpSession.send_and_read_async(request, GLib.PRIORITY_DEFAULT, null, (httpSession, result) => {
+                    try {
+                        this._processMessageRefresh(result);
+                    } finally {
+                        this._pendingMessages?.delete(request);
+                    }
                 });
             }
             catch(error) {
+                this._pendingMessages?.delete(request);
                 BingLog('unable to send libsoup json message '+error);
                 notifyError('Unable to fetch Bing metadata\n'+error);
             }
@@ -679,14 +692,22 @@ class BingWallpaperIndicator extends Button {
             let url = BingImageURL + '?format=js&idx=0&n=8&mbl=1&mkt=' + (market != 'auto' ? market : '');
             let request = Soup.Message.new('GET', url);
             request.request_headers.append('Accept', 'application/json');
+            this._pendingMessages?.add(request);
 
             // queue the http request
             try {
+                // Soup 2 queue_message callback is (session, soupMessage);
+                // the second arg is the same wrapper we pinned.
                 this.httpSession.queue_message(request, (httpSession, message) => {
-                    this._processMessageRefresh(message);
+                    try {
+                        this._processMessageRefresh(message);
+                    } finally {
+                        this._pendingMessages?.delete(message);
+                    }
                 });
             }
             catch (error) {
+                this._pendingMessages?.delete(request);
                 BingLog('unable to send libsoup json message '+error);
                 notifyError('Unable to fetch Bing metadata\n'+error);
             }
@@ -1047,21 +1068,34 @@ class BingWallpaperIndicator extends Button {
         }
         BingLog("Downloading " + url + " to " + file.get_uri());
         let request = Soup.Message.new('GET', url);
+        this._pendingMessages?.add(request);
 
         // queue the http request
         try {
             if (Soup.MAJOR_VERSION >= 3) {
-                await this.httpSession.send_and_read_async(request, GLib.PRIORITY_DEFAULT, null, (httpSession, message) => {
-                    this._processFileDownload(message, file, set_background);
+                // Soup 3 callback is (session, asyncResult); pinned msg
+                // lives in the closure as `request`.
+                await this.httpSession.send_and_read_async(request, GLib.PRIORITY_DEFAULT, null, (httpSession, result) => {
+                    try {
+                        this._processFileDownload(result, file, set_background);
+                    } finally {
+                        this._pendingMessages?.delete(request);
+                    }
                 });
             }
             else {
+                // Soup 2 queue_message callback is (session, soupMessage).
                 this.httpSession.queue_message(request, (httpSession, message) => {
-                    this._processFileDownload(message, file, set_background);
+                    try {
+                        this._processFileDownload(message, file, set_background);
+                    } finally {
+                        this._pendingMessages?.delete(message);
+                    }
                 });
             }
         }
         catch (error) {
+            this._pendingMessages?.delete(request);
             BingLog('error sending libsoup message '+error);
             notifyError('Network error '+error);
         }
@@ -1119,6 +1153,16 @@ class BingWallpaperIndicator extends Button {
 
         this._timeout = undefined;
         this._shuffleTimeout = undefined;
+
+        if (this.httpSession) {
+            this.httpSession.abort();
+            this.httpSession = null;
+        }
+        if (this._pendingMessages) {
+            this._pendingMessages.clear();
+            this._pendingMessages = null;
+        }
+
         this.menu.removeAll();
     }
 });


### PR DESCRIPTION
## Summary

GNOME Shell journal carries a recurring warning that points back at this extension:

```
gnome-shell[…]: (../libsoup/soup-message-queue-item.c:46):soup_message_queue_item_destroy:
runtime check failed: (soup_message_get_connection (item->msg) == NULL)
```

It fires whenever GC reaps the JS wrapper for a `Soup.Message` while libsoup is still tearing down its queue item — the C-side queue item disposal can finish on a later main-loop iteration than the `send_and_read_async` callback. With the message wrapper unreachable in the meantime, the runtime check trips. The same pattern affects several extensions in the GJS ecosystem (e.g. azclock); pinning the messages until libsoup is done with them silences it.

## Changes

`extension.js` only — the prefs-side `fetch_change_log` in `utils.js` runs in a separate process and is much less likely to be heard, so I left it for a follow-up.

- `_initSoup()`: add `this._pendingMessages = new Set()` next to the `Soup.Session`.
- `_refresh()`:
  - Soup 3 path: `_pendingMessages.add(request)` before `send_and_read_async`. Callback signature is `(session, asyncResult)` — the message we pinned lives in the closure as `request`, so the `finally` deletes `request` (not the callback's second arg, which is an `AsyncResult`).
  - Soup 2 `queue_message` path: same pin, and the callback's second arg there *is* the `Soup.Message`, so the delete uses the callback arg directly.
  - Synchronous `catch` paths delete `request` so a thrown send doesn't leave a phantom pin.
- `_downloadImage()`: same treatment for both Soup 3 and Soup 2 paths.
- `stop()`: abort the session, null it, and clear the Set so `disable()` doesn't leak.

The optional chains on `?.add` / `?.delete` are defensive in case `stop()` ran while a callback was still queued.

## How to verify

Without the patch:

```bash
journalctl -t gnome-shell -fb | grep soup_message_queue_item
```

…shows the runtime check firing every few minutes once the extension has been alive for a while. With the patch installed (and other Soup-using extensions disabled to bisect) the check goes silent. I've verified the same pattern silences the equivalent warning in azclock.

Marking as draft because I'd like a maintainer's eye on the choice not to apply the same fix to `utils.js` — happy to extend the PR if you'd prefer parity.