### PR TITLE
Fix JSON import/export: mixed callback+await on Gio.File async calls

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -12,6 +12,9 @@ import GLib from 'gi://GLib';
 import Soup from 'gi://Soup';
 import GdkPixbuf from 'gi://GdkPixbuf';
 
+Gio._promisify(Gio.File.prototype, 'load_contents_async', 'load_contents_finish');
+Gio._promisify(Gio.File.prototype, 'replace_contents_async', 'replace_contents_finish');
+
 export var BING_SCHEMA = 'org.gnome.shell.extensions.bingwallpaper';
 export var DESKTOP_SCHEMA = 'org.gnome.desktop.background';
 
@@ -587,21 +590,18 @@ export async function exportBingJSON(settings) {
     let filepath = getWallpaperDir(settings) + 'bing.json';
     let file = Gio.file_new_for_path(filepath);
 
-    const [etag] = await file.replace_contents_async(
-        json,
-        null,
-        false,
-        Gio.FileCreateFlags.REPLACE_DESTINATION,
-        null,
-        (file, res) => {
-            try {
-                file.replace_contents_finish(res);
-            } 
-            catch(e) {
-                BingLog('error saving bing-json from '+filepath+': '+e);
-            }
-        }
-    );
+    try {
+        const [etag] = await file.replace_contents_async(
+            new TextEncoder().encode(json),
+            null,
+            false,
+            Gio.FileCreateFlags.REPLACE_DESTINATION,
+            null
+        );
+    }
+    catch(e) {
+        BingLog('error saving bing-json from '+filepath+': '+e);
+    }
 }
 
 export async function importBingJSON(settings) {
@@ -609,21 +609,17 @@ export async function importBingJSON(settings) {
     let filepath = getWallpaperDir(settings) + 'bing.json';
     let file = Gio.file_new_for_path(filepath);
     if (file.query_exists(null)) {
-        const [contents, etag] = await file.load_contents_async(null,
-            (file, res) => {
-                try {
-                    BingLog('JSON import success');
-                    let parsed = JSON.parse(decoder.decode(contents)); // FIXME: triggers GJS warning without the conversion, need to investigate
-                    // need to implement some checks for validity here
-                    mergeImageLists(settings, parsed);
-                    purgeImages(settings); // remove the older missing images
-                    file.load_contents_finish(res);
-                }
-                catch (e) {
-                    BingLog('error loading bing-json '+filepath+' - '+e);
-                }
-            }
-        );
+        try {
+            const [contents, etag] = await file.load_contents_async(null);
+            BingLog('JSON import success');
+            let parsed = JSON.parse(decoder.decode(contents));
+            // need to implement some checks for validity here
+            mergeImageLists(settings, parsed);
+            purgeImages(settings); // remove the older missing images
+        }
+        catch (e) {
+            BingLog('error loading bing-json '+filepath+' - '+e);
+        }
     }
     else {
         BingLog('JSON import file not found');


### PR DESCRIPTION
Fixes #280

## Root cause

The "use async file functions" / "fix async errors" commits (a6868f4, 0f3e0be)
converted `exportBingJSON`/`importBingJSON` to use `replace_contents_async`/
`load_contents_async`, but kept the old callback-style argument while also
adding `await`. `Gio.File`'s async methods only return a Promise when called
*without* an explicit callback, so:

- The awaited call resolved immediately to `undefined` (no callback passed =
  no promise), and destructuring it threw a `TypeError` as an unhandled
  promise rejection before the file was ever read.
- The callback itself, when it later fired, tried to read `contents` from the
  outer (never-initialized) `const` binding, throwing a `ReferenceError`
  caught only by its own inner `try/catch` and logged through `BingLog`
  (silent unless debug mode is on).

Net effect: both Import and Export silently did nothing — matches the
behavior reported in #280.

`exportBingJSON` also passed a raw JS string to `replace_contents_async`,
which requires a `GBytes` argument, so even a correctly-awaited version would
still have thrown.

## Fix

- Explicitly promisify both methods with `Gio._promisify` (GJS does not
  auto-promisify them in this context).
- Drop the callbacks in favor of plain `await`, each wrapped in `try/catch`.
- Encode the JSON string with `TextEncoder` before writing.

## Testing

Verified with an isolated GJS test using a memory-backed `GSettings`
instance (no real dconf/files touched): round-tripped a 927-entry
`bing.json` through import then export with no data loss.